### PR TITLE
fix #57

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: aoh
 Type: Package
-Version: 0.0.2.12
+Version: 0.0.2.13
 Title: Create Area of Habitat Data
 Description: Create Area of Habitat data to characterize species distributions.
     Data are produced following procedures outlined by Brooks et al. (2019)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# aoh 0.0.2.13
+
+- Update `read_spp_range_data()` and `create_spp_info_data()` to fix
+  incompatibility issue with latest version of the BirdLife species range
+  dataset (#57). Thanks to Jianqiao Zhao for the bug report.
+- Update `create_spp_aoh_data()` and `create_spp_frc_data()` so that they
+  provide a correct error message when the argument to `x` does not
+  contain an `"id_no"` column.
+
 # aoh 0.0.2.12
 
 - Fix bug in `create_spp_info_data()` in assigning habitat types for resident

--- a/R/clean_spp_range_data.R
+++ b/R/clean_spp_range_data.R
@@ -125,20 +125,22 @@ clean_spp_range_data <- function(x,
   )
   assertthat::assert_that(
     assertthat::has_name(x, "id_no") ||
+      assertthat::has_name(x, "sisid") ||
       assertthat::has_name(x, "SISID") ||
       assertthat::has_name(x, "SISRecID"),
-    msg = paste0(
-      "argument to \"x\" must have a \"id_no\", \"SISID\", ",
-      "or \"SISRecID\" column"
+    msg = paste(
+      "argument to \"x\" must have a recognized species identifier column",
+      "(i.e., a column named \"id_no\", \"sisid\", \"SISID\", or",
+      "\"SISRecID\")"
     )
   )
   assertthat::assert_that(
     assertthat::has_name(x, "binomial") ||
       assertthat::has_name(x, "SCINAME") ||
       assertthat::has_name(x, "sci_name"),
-    msg = paste0(
-      "argument to \"x\" must have a \"binomial\", \"SCINAME\", ",
-      "or \"sci_name\" column"
+    msg = paste(
+      "argument to \"x\" must have a recognized species name column",
+      "(i.e., a column named \"binomial\", \"SCINAME\", or \"sci_name\")"
     )
   )
   assertthat::assert_that(

--- a/R/create_spp_data.R
+++ b/R/create_spp_data.R
@@ -103,11 +103,8 @@ create_spp_data <- function(x,
     msg = "argument to \"cache_limit\" cannot exceed 9999"
   )
   assertthat::assert_that(
-    assertthat::has_name(x, "id_no") ||
-      assertthat::has_name(x, "SISID"),
-    msg = paste0(
-      "argument to \"x\" does not have a column named \"id_no\" or \"SISID\""
-    )
+    assertthat::has_name(x, "id_no"),
+    msg = "argument to \"x\" does not have a column named \"id_no\""
   )
   if (identical(engine, "gdal")) {
   assertthat::assert_that(

--- a/R/create_spp_info_data.R
+++ b/R/create_spp_info_data.R
@@ -373,9 +373,11 @@ create_spp_info_data <- function(x,
   )
   assertthat::assert_that(
     assertthat::has_name(x, "id_no") ||
-      assertthat::has_name(x, "SISID"),
-    msg = paste0(
-      "argument to \"x\" does not have a column named \"id_no\" or \"SISID\""
+      assertthat::has_name(x, "SISID") ||
+      assertthat::has_name(x, "sisid"),
+    msg = paste(
+      "argument to \"x\" does not have a recognized species identifier column",
+      "(i.e., a column named \"id_no\", \"sisid\", or \"SISID\")"
     )
   )
 

--- a/R/read_spp_range_data.R
+++ b/R/read_spp_range_data.R
@@ -138,6 +138,8 @@ read_spp_range_data <- function(path, n = NULL) {
     ## find range data id column
     if (assertthat::has_name(out, "id_no")) {
       id_col <- "id_no"
+    } else if (assertthat::has_name(out, "sisid")) {
+      id_col <- "sisid"
     } else if (assertthat::has_name(out, "SISID")) {
       id_col <- "SISID"
     } else if (assertthat::has_name(out, "SISRecID")) {
@@ -145,21 +147,25 @@ read_spp_range_data <- function(path, n = NULL) {
     } else {
       stop(
         "range data in argument to \"path\" does not contain ",
-        "\"id_no\", \"SISID\", or \"SISRecID\" columns"
+        "a recognized species identifier column (i.e., a column named ",
+        "\"id_no\", \"sisid\", \"SISID\", or \"SISRecID\")"
       )
     }
     ## rename column in metadata
     if (!assertthat::has_name(md, id_col)) {
       if (assertthat::has_name(md, "id_no")) {
         names(md)[which(names(md) == "id_no")[[1]]] <- id_col
+      } else if (assertthat::has_name(md, "sisid")) {
+        names(md)[which(names(md) == "sisid")[[1]]] <- id_col
       } else if (assertthat::has_name(md, "SISID")) {
         names(md)[which(names(md) == "SISID")[[1]]] <- id_col
       } else if (assertthat::has_name(md, "SISRecID")) {
         names(md)[which(names(md) == "SISRecID")[[1]]] <- id_col
       } else {
         stop(
-        "species metadata in argument to \"path\" does not contain ",
-        "\"id_no\", \"SISID\", or \"SISRecID\" columns"
+          "species metadata in argument to \"path\" does not contain ",
+          "a recognized species identifier column (i.e., a column named ",
+          "\"id_no\", \"sisid\", \"SISID\", or \"SISRecID\")"
         )
       }
     }


### PR DESCRIPTION
- Update `read_spp_range_data()` and `create_spp_info_data()` to fix
  incompatibility issue with latest version of the BirdLife species range
  dataset (#57). Thanks to Jianqiao Zhao for the bug report.
- Update `create_spp_aoh_data()` and `create_spp_frc_data()` so that they
  provide a correct error message when the argument to `x` does not
  contain an `"id_no"` column.
